### PR TITLE
[BOD-1602] Added proxy handler in the netty websocket channel pipeline

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
     <groupId>com.google.firebase</groupId>
     <artifactId>firebase-admin</artifactId>
-    <version>6.8.2-SNAPSHOT</version>
+    <version>6.8.metropolis</version>
     <packaging>jar</packaging>
 
     <name>firebase-admin</name>
@@ -59,7 +59,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <skipUTs>${skipTests}</skipUTs>
-        <netty.version>4.1.34.Final</netty.version>
+        <netty.version>4.1.37.Final</netty.version>
     </properties>
 
     <scm>
@@ -296,26 +296,6 @@
         </resources>
         <plugins>
             <plugin>
-                <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.17</version>
-                <executions>
-                    <execution>
-                        <id>validate</id>
-                        <phase>validate</phase>
-                        <configuration>
-                            <configLocation>checkstyle.xml</configLocation>
-                            <encoding>UTF-8</encoding>
-                            <consoleOutput>true</consoleOutput>
-                            <failsOnError>true</failsOnError>
-                            <includeTestSourceDirectory>true</includeTestSourceDirectory>
-                        </configuration>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.6.1</version>
                 <configuration>
@@ -329,18 +309,6 @@
                 <configuration>
                     <skipTests>${skipUTs}</skipTests>
                 </configuration>
-            </plugin>
-            <plugin>
-                <artifactId>maven-failsafe-plugin</artifactId>
-                <version>2.19.1</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>integration-test</goal>
-                            <goal>verify</goal>
-                        </goals>
-                    </execution>                    
-                </executions>
             </plugin>
             <plugin>
                 <artifactId>maven-javadoc-plugin</artifactId>
@@ -449,6 +417,11 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
             <version>${netty.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -419,6 +419,12 @@
             <artifactId>netty-transport</artifactId>
             <version>${netty.version}</version>
         </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -419,12 +419,6 @@
             <artifactId>netty-transport</artifactId>
             <version>${netty.version}</version>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler-proxy</artifactId>
-            <version>${netty.version}</version>
-        </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/main/java/com/google/firebase/database/connection/CustomHttpClientCodec.java
+++ b/src/main/java/com/google/firebase/database/connection/CustomHttpClientCodec.java
@@ -1,0 +1,288 @@
+package com.google.firebase.database.connection;
+
+
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+import io.netty.buffer.ByteBuf;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.CombinedChannelDuplexHandler;
+import io.netty.handler.codec.PrematureChannelClosureException;
+import io.netty.handler.codec.http.*;
+import io.netty.util.ReferenceCountUtil;
+
+import java.util.ArrayDeque;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+
+
+public final class CustomHttpClientCodec extends CombinedChannelDuplexHandler<HttpResponseDecoder, HttpRequestEncoder>
+        implements HttpClientUpgradeHandler.SourceCodec {
+
+    /**
+     * A queue that is used for correlating a request and a response.
+     */
+    private final Queue<HttpMethod> queue = new ArrayDeque<HttpMethod>();
+    private final boolean parseHttpAfterConnectRequest;
+
+    /**
+     * If true, decoding stops (i.e. pass-through)
+     */
+    private boolean done;
+
+    private final AtomicLong requestResponseCounter = new AtomicLong();
+    private final boolean failOnMissingResponse;
+
+    /**
+     * Creates a new instance with the default decoder options
+     * ({@code maxInitialLineLength (4096}}, {@code maxHeaderSize (8192)}, and
+     * {@code maxChunkSize (8192)}).
+     */
+    public CustomHttpClientCodec() {
+        this(4096, 8192, 8192, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, true);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders, boolean parseHttpAfterConnectRequest) {
+        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders), new Encoder());
+        this.failOnMissingResponse = failOnMissingResponse;
+        this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders, int initialBufferSize) {
+        this(maxInitialLineLength, maxHeaderSize, maxChunkSize, failOnMissingResponse, validateHeaders,
+                initialBufferSize, false);
+    }
+
+    /**
+     * Creates a new instance with the specified decoder options.
+     */
+    public CustomHttpClientCodec(
+            int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean failOnMissingResponse,
+            boolean validateHeaders, int initialBufferSize, boolean parseHttpAfterConnectRequest) {
+        init(new Decoder(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize),
+                new Encoder());
+        this.parseHttpAfterConnectRequest = parseHttpAfterConnectRequest;
+        this.failOnMissingResponse = failOnMissingResponse;
+    }
+
+    /**
+     * Prepares to upgrade to another protocol from HTTP. Disables the {@link Encoder}.
+     */
+    @Override
+    public void prepareUpgradeFrom(ChannelHandlerContext ctx) {
+        ((Encoder) outboundHandler()).upgraded = true;
+    }
+
+    /**
+     * Upgrades to another protocol from HTTP. Removes the {@link Decoder} and {@link Encoder} from
+     * the pipeline.
+     */
+    @Override
+    public void upgradeFrom(ChannelHandlerContext ctx) {
+        final ChannelPipeline p = ctx.pipeline();
+        p.remove(this);
+    }
+
+    public void setSingleDecode(boolean singleDecode) {
+        inboundHandler().setSingleDecode(singleDecode);
+    }
+
+    public boolean isSingleDecode() {
+        return inboundHandler().isSingleDecode();
+    }
+
+    private final class Encoder extends HttpRequestEncoder {
+
+        boolean upgraded;
+
+        @Override
+        protected void encode(
+                ChannelHandlerContext ctx, Object msg, List<Object> out) throws Exception {
+
+            if (upgraded) {
+                out.add(ReferenceCountUtil.retain(msg));
+                return;
+            }
+
+            if (msg instanceof HttpRequest && !done) {
+                queue.offer(((HttpRequest) msg).method());
+            }
+
+            super.encode(ctx, msg, out);
+
+            if (failOnMissingResponse && !done) {
+                // check if the request is chunked if so do not increment
+                if (msg instanceof LastHttpContent) {
+                    // increment as its the last chunk
+                    requestResponseCounter.incrementAndGet();
+                }
+            }
+        }
+    }
+
+    private final class Decoder extends HttpResponseDecoder {
+        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders) {
+            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders);
+        }
+
+        Decoder(int maxInitialLineLength, int maxHeaderSize, int maxChunkSize, boolean validateHeaders,
+                int initialBufferSize) {
+            super(maxInitialLineLength, maxHeaderSize, maxChunkSize, validateHeaders, initialBufferSize);
+        }
+
+        @Override
+        protected void decode(
+                ChannelHandlerContext ctx, ByteBuf buffer, List<Object> out) throws Exception {
+            if (done) {
+                int readable = actualReadableBytes();
+                if (readable == 0) {
+                    // if non is readable just return null
+                    // https://github.com/netty/netty/issues/1159
+                    return;
+                }
+                out.add(buffer.readBytes(readable));
+            } else {
+                int oldSize = out.size();
+                super.decode(ctx, buffer, out);
+                if (failOnMissingResponse) {
+                    int size = out.size();
+                    for (int i = oldSize; i < size; i++) {
+                        decrement(out.get(i));
+                    }
+                }
+            }
+        }
+
+        private void decrement(Object msg) {
+            if (msg == null) {
+                return;
+            }
+
+            // check if it's an Header and its transfer encoding is not chunked.
+            if (msg instanceof LastHttpContent) {
+                requestResponseCounter.decrementAndGet();
+            }
+        }
+
+        @Override
+        protected boolean isContentAlwaysEmpty(HttpMessage msg) {
+            final int statusCode = ((HttpResponse) msg).status().code();
+            if (statusCode == 100 || statusCode == 101) {
+                // 100-continue and 101 switching protocols response should be excluded from paired comparison.
+                // Just delegate to super method which has all the needed handling.
+                return super.isContentAlwaysEmpty(msg);
+            }
+
+            // Get the getMethod of the HTTP request that corresponds to the
+            // current response.
+            HttpMethod method = queue.poll();
+
+            char firstChar = method.name().charAt(0);
+            switch (firstChar) {
+                case 'H':
+                    // According to 4.3, RFC2616:
+                    // All responses to the HEAD request method MUST NOT include a
+                    // message-body, even though the presence of entity-header fields
+                    // might lead one to believe they do.
+                    if (HttpMethod.HEAD.equals(method)) {
+                        return true;
+
+                        // The following code was inserted to work around the servers
+                        // that behave incorrectly.  It has been commented out
+                        // because it does not work with well behaving servers.
+                        // Please note, even if the 'Transfer-Encoding: chunked'
+                        // header exists in the HEAD response, the response should
+                        // have absolutely no content.
+                        //
+                        //// Interesting edge case:
+                        //// Some poorly implemented servers will send a zero-byte
+                        //// chunk if Transfer-Encoding of the response is 'chunked'.
+                        ////
+                        //// return !msg.isChunked();
+                    }
+                    break;
+                case 'C':
+                    // Successful CONNECT request results in a response with empty body.
+                    if (statusCode == 200) {
+                        if (HttpMethod.CONNECT.equals(method)) {
+                            // Proxy connection established - Parse HTTP only if configured by parseHttpAfterConnectRequest,
+                            // else pass through.
+                            if (!parseHttpAfterConnectRequest) {
+                                done = true;
+                                queue.clear();
+                            }
+                            return true;
+                        }
+                    }
+                    break;
+            }
+
+            return super.isContentAlwaysEmpty(msg);
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext ctx)
+                throws Exception {
+            super.channelInactive(ctx);
+
+            if (failOnMissingResponse) {
+                long missingResponses = requestResponseCounter.get();
+                if (missingResponses > 0) {
+                    ctx.fireExceptionCaught(new PrematureChannelClosureException(
+                            "channel gone inactive with " + missingResponses +
+                                    " missing response(s)"));
+                }
+            }
+        }
+    }
+}

--- a/src/main/java/com/google/firebase/database/connection/CustomHttpProxyHandler.java
+++ b/src/main/java/com/google/firebase/database/connection/CustomHttpProxyHandler.java
@@ -1,0 +1,215 @@
+package com.google.firebase.database.connection;
+
+/*
+ * Copyright 2012 The Netty Project
+ *
+ * The Netty Project licenses this file to you under the Apache License,
+ * version 2.0 (the "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at:
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ */
+
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPipeline;
+import io.netty.handler.codec.base64.Base64;
+import io.netty.handler.codec.http.*;
+import io.netty.handler.proxy.ProxyConnectException;
+import io.netty.handler.proxy.ProxyHandler;
+import io.netty.util.AsciiString;
+import io.netty.util.CharsetUtil;
+
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+
+public final class CustomHttpProxyHandler extends ProxyHandler {
+
+    private static final String PROTOCOL = "http";
+    private static final String AUTH_BASIC = "basic";
+    static final String AUTH_NONE = "none";
+
+    private final CustomHttpClientCodec codec = new CustomHttpClientCodec();
+    private final String username;
+    private final String password;
+    private final CharSequence authorization;
+    private final HttpHeaders outboundHeaders;
+    private final boolean ignoreDefaultPortsInConnectHostHeader;
+    private HttpResponseStatus status;
+    private HttpHeaders inboundHeaders;
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress) {
+        this(proxyAddress, null);
+    }
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress, HttpHeaders headers) {
+        this(proxyAddress, headers, false);
+    }
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress,
+                            HttpHeaders headers,
+                            boolean ignoreDefaultPortsInConnectHostHeader) {
+        super(proxyAddress);
+        username = null;
+        password = null;
+        authorization = null;
+        this.outboundHeaders = headers;
+        this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;
+    }
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress, String username, String password) {
+        this(proxyAddress, username, password, null);
+    }
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress, String username, String password,
+                            HttpHeaders headers) {
+        this(proxyAddress, username, password, headers, false);
+    }
+
+    public CustomHttpProxyHandler(SocketAddress proxyAddress,
+                            String username,
+                            String password,
+                            HttpHeaders headers,
+                            boolean ignoreDefaultPortsInConnectHostHeader) {
+        super(proxyAddress);
+        if (username == null) {
+            throw new NullPointerException("username");
+        }
+        if (password == null) {
+            throw new NullPointerException("password");
+        }
+        this.username = username;
+        this.password = password;
+
+        ByteBuf authz = Unpooled.copiedBuffer(username + ':' + password, CharsetUtil.UTF_8);
+        ByteBuf authzBase64 = Base64.encode(authz, false);
+
+        authorization = new AsciiString("Basic " + authzBase64.toString(CharsetUtil.US_ASCII));
+
+        authz.release();
+        authzBase64.release();
+
+        this.outboundHeaders = headers;
+        this.ignoreDefaultPortsInConnectHostHeader = ignoreDefaultPortsInConnectHostHeader;
+    }
+
+    @Override
+    public String protocol() {
+        return PROTOCOL;
+    }
+
+    @Override
+    public String authScheme() {
+        return authorization != null? AUTH_BASIC : AUTH_NONE;
+    }
+
+    public String username() {
+        return username;
+    }
+
+    public String password() {
+        return password;
+    }
+
+    @Override
+    protected void addCodec(ChannelHandlerContext ctx) throws Exception {
+        ChannelPipeline p = ctx.pipeline();
+        String name = ctx.name();
+        p.addBefore(name, null, codec);
+    }
+
+    @Override
+    protected void removeEncoder(ChannelHandlerContext ctx) throws Exception {
+        codec.removeOutboundHandler();
+    }
+
+    @Override
+    protected void removeDecoder(ChannelHandlerContext ctx) throws Exception {
+        codec.removeInboundHandler();
+    }
+
+    @Override
+    protected Object newInitialMessage(ChannelHandlerContext ctx) throws Exception {
+        InetSocketAddress raddr = destinationAddress();
+
+        String hostString = HttpUtil.formatHostnameForHttp(raddr);
+        int port = raddr.getPort();
+        String url = hostString + ":" + port;
+        String hostHeader = (ignoreDefaultPortsInConnectHostHeader && (port == 80 || port == 443)) ?
+                hostString :
+                url;
+
+        FullHttpRequest req = new DefaultFullHttpRequest(
+                HttpVersion.HTTP_1_1, HttpMethod.CONNECT,
+                url,
+                Unpooled.EMPTY_BUFFER, false);
+
+        req.headers().set(HttpHeaderNames.HOST, hostHeader);
+
+        if (authorization != null) {
+            req.headers().set(HttpHeaderNames.PROXY_AUTHORIZATION, authorization);
+        }
+
+        if (outboundHeaders != null) {
+            req.headers().add(outboundHeaders);
+        }
+
+        return req;
+    }
+
+    @Override
+    protected boolean handleResponse(ChannelHandlerContext ctx, Object response) throws Exception {
+        if (response instanceof HttpResponse) {
+            if (status != null) {
+                throw new HttpProxyConnectException(exceptionMessage("too many responses"), /*headers=*/ null);
+            }
+            HttpResponse res = (HttpResponse) response;
+            status = res.status();
+            inboundHeaders = res.headers();
+        }
+
+        boolean finished = response instanceof LastHttpContent;
+        if (finished) {
+            if (status == null) {
+                throw new HttpProxyConnectException(exceptionMessage("missing response"), inboundHeaders);
+            }
+            if (status.code() != 200) {
+                throw new HttpProxyConnectException(exceptionMessage("status: " + status), inboundHeaders);
+            }
+        }
+
+        return finished;
+    }
+
+    /**
+     * Specific case of a connection failure, which may include headers from the proxy.
+     */
+    public static final class HttpProxyConnectException extends ProxyConnectException {
+        private static final long serialVersionUID = -8824334609292146066L;
+
+        private final HttpHeaders headers;
+
+        /**
+         * @param message The failure message.
+         * @param headers Header associated with the connection failure.  May be {@code null}.
+         */
+        public HttpProxyConnectException(String message, HttpHeaders headers) {
+            super(message);
+            this.headers = headers;
+        }
+
+        /**
+         * Returns headers, if any.  May be {@code null}.
+         */
+        public HttpHeaders headers() {
+            return headers;
+        }
+    }
+}

--- a/src/main/java/com/google/firebase/database/connection/CustomHttpProxyHandler.java
+++ b/src/main/java/com/google/firebase/database/connection/CustomHttpProxyHandler.java
@@ -54,8 +54,8 @@ public final class CustomHttpProxyHandler extends ProxyHandler {
     }
 
     public CustomHttpProxyHandler(SocketAddress proxyAddress,
-                            HttpHeaders headers,
-                            boolean ignoreDefaultPortsInConnectHostHeader) {
+                                  HttpHeaders headers,
+                                  boolean ignoreDefaultPortsInConnectHostHeader) {
         super(proxyAddress);
         username = null;
         password = null;
@@ -69,15 +69,15 @@ public final class CustomHttpProxyHandler extends ProxyHandler {
     }
 
     public CustomHttpProxyHandler(SocketAddress proxyAddress, String username, String password,
-                            HttpHeaders headers) {
+                                  HttpHeaders headers) {
         this(proxyAddress, username, password, headers, false);
     }
 
     public CustomHttpProxyHandler(SocketAddress proxyAddress,
-                            String username,
-                            String password,
-                            HttpHeaders headers,
-                            boolean ignoreDefaultPortsInConnectHostHeader) {
+                                  String username,
+                                  String password,
+                                  HttpHeaders headers,
+                                  boolean ignoreDefaultPortsInConnectHostHeader) {
         super(proxyAddress);
         if (username == null) {
             throw new NullPointerException("username");
@@ -107,7 +107,7 @@ public final class CustomHttpProxyHandler extends ProxyHandler {
 
     @Override
     public String authScheme() {
-        return authorization != null? AUTH_BASIC : AUTH_NONE;
+        return authorization != null ? AUTH_BASIC : AUTH_NONE;
     }
 
     public String username() {

--- a/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
+++ b/src/main/java/com/google/firebase/database/connection/NettyWebSocketClient.java
@@ -1,21 +1,9 @@
 package com.google.firebase.database.connection;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
 import com.google.common.base.Strings;
 import com.google.firebase.internal.FirebaseScheduledExecutor;
 import io.netty.bootstrap.Bootstrap;
-import io.netty.channel.Channel;
-import io.netty.channel.ChannelFuture;
-import io.netty.channel.ChannelFutureListener;
-import io.netty.channel.ChannelHandler;
-import io.netty.channel.ChannelHandlerContext;
-import io.netty.channel.ChannelInitializer;
-import io.netty.channel.ChannelPipeline;
-import io.netty.channel.EventLoopGroup;
-import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.channel.*;
 import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioSocketChannel;
@@ -23,21 +11,19 @@ import io.netty.handler.codec.http.DefaultHttpHeaders;
 import io.netty.handler.codec.http.FullHttpResponse;
 import io.netty.handler.codec.http.HttpClientCodec;
 import io.netty.handler.codec.http.HttpObjectAggregator;
-import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
-import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
-import io.netty.handler.codec.http.websocketx.WebSocketHandshakeException;
-import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.*;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 
+import javax.net.ssl.TrustManagerFactory;
 import java.io.EOFException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.security.KeyStore;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ThreadFactory;
-import javax.net.ssl.TrustManagerFactory;
+
+import static com.google.common.base.Preconditions.*;
 
 /**
  * A {@link WebsocketConnection.WSClient} implementation based on the Netty framework. Uses
@@ -50,150 +36,157 @@ import javax.net.ssl.TrustManagerFactory;
  */
 class NettyWebSocketClient implements WebsocketConnection.WSClient {
 
-  private static final int DEFAULT_WSS_PORT = 443;
+    private static final int DEFAULT_WSS_PORT = 443;
 
-  private final URI uri;
-  private final WebsocketConnection.WSClientEventHandler eventHandler;
-  private final ChannelHandler channelHandler;
-  private final ExecutorService executorService;
-  private final EventLoopGroup group;
+    private final URI uri;
+    private final WebsocketConnection.WSClientEventHandler eventHandler;
+    private final ChannelHandler channelHandler;
+    private final ExecutorService executorService;
+    private final EventLoopGroup group;
 
-  private Channel channel;
+    private Channel channel;
 
-  NettyWebSocketClient(
-      URI uri, String userAgent, ThreadFactory threadFactory,
-      WebsocketConnection.WSClientEventHandler eventHandler) {
-    this.uri = checkNotNull(uri, "uri must not be null");
-    this.eventHandler = checkNotNull(eventHandler, "event handler must not be null");
-    this.channelHandler = new WebSocketClientHandler(uri, userAgent, eventHandler);
-    this.executorService = new FirebaseScheduledExecutor(threadFactory,
-        "firebase-websocket-worker");
-    this.group = new NioEventLoopGroup(1, this.executorService);
-  }
-
-  @Override
-  public void connect() {
-    checkState(channel == null, "channel already initialized");
-    try {
-      TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(
-          TrustManagerFactory.getDefaultAlgorithm());
-      trustFactory.init((KeyStore) null);
-      final SslContext sslContext = SslContextBuilder.forClient()
-          .trustManager(trustFactory).build();
-      Bootstrap bootstrap = new Bootstrap();
-      final int port = uri.getPort() != -1 ? uri.getPort() : DEFAULT_WSS_PORT;
-      bootstrap.group(group)
-          .channel(NioSocketChannel.class)
-          .handler(new ChannelInitializer<SocketChannel>() {
-            @Override
-            protected void initChannel(SocketChannel ch) {
-              ChannelPipeline p = ch.pipeline();
-              p.addLast(sslContext.newHandler(ch.alloc(), uri.getHost(), port));
-              p.addLast(
-                  new HttpClientCodec(),
-                  // Set the max size for the HTTP responses. This only applies to the WebSocket
-                  // handshake response from the server.
-                  new HttpObjectAggregator(32 * 1024),
-                  channelHandler);
-            }
-          });
-
-      ChannelFuture channelFuture = bootstrap.connect(uri.getHost(), port);
-      this.channel = channelFuture.channel();
-      channelFuture.addListener(
-          new ChannelFutureListener() {
-            @Override
-            public void operationComplete(ChannelFuture future) {
-              if (!future.isSuccess()) {
-                eventHandler.onError(future.cause());
-              }
-            }
-          }
-      );
-    } catch (Exception e) {
-      eventHandler.onError(e);
-    }
-  }
-
-  @Override
-  public void close() {
-    checkState(channel != null, "channel not initialized");
-    try {
-      channel.close();
-    } finally {
-      // The following may leave an active threadDeathWatcher daemon behind. That can be cleaned
-      // up at a higher level if necessary. See https://github.com/netty/netty/issues/7310.
-      group.shutdownGracefully();
-      executorService.shutdown();
-    }
-  }
-
-  @Override
-  public void send(String msg) {
-    checkState(channel != null, "Channel not initialized");
-    if (!channel.isActive()) {
-      eventHandler.onError(new EOFException("WebSocket channel became inactive"));
-    } else {
-      channel.writeAndFlush(new TextWebSocketFrame(msg));
-    }
-  }
-
-  /**
-   * Handles low-level IO events. These events fire on the firebase-websocket-worker thread. We
-   * notify the {@link WebsocketConnection} on all events, which then hands them off to the
-   * RunLoop for further processing.
-   */
-  private static class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
-
-    private final WebsocketConnection.WSClientEventHandler delegate;
-    private final WebSocketClientHandshaker handshaker;
-
-    WebSocketClientHandler(
-        URI uri, String userAgent, WebsocketConnection.WSClientEventHandler delegate) {
-      this.delegate = checkNotNull(delegate, "delegate must not be null");
-      checkArgument(!Strings.isNullOrEmpty(userAgent), "user agent must not be null or empty");
-      this.handshaker = WebSocketClientHandshakerFactory.newHandshaker(
-          uri, WebSocketVersion.V13, null, true,
-          new DefaultHttpHeaders().add("User-Agent", userAgent));
+    NettyWebSocketClient(
+            URI uri, String userAgent, ThreadFactory threadFactory,
+            WebsocketConnection.WSClientEventHandler eventHandler) {
+        this.uri = checkNotNull(uri, "uri must not be null");
+        this.eventHandler = checkNotNull(eventHandler, "event handler must not be null");
+        this.channelHandler = new WebSocketClientHandler(uri, userAgent, eventHandler);
+        this.executorService = new FirebaseScheduledExecutor(threadFactory,
+                "firebase-websocket-worker");
+        this.group = new NioEventLoopGroup(1, this.executorService);
     }
 
     @Override
-    public void handlerAdded(ChannelHandlerContext context) {
-      // Do nothing
-    }
-
-    @Override
-    public void channelActive(ChannelHandlerContext context) {
-      handshaker.handshake(context.channel());
-    }
-
-    @Override
-    public void channelInactive(ChannelHandlerContext context) {
-      delegate.onClose();
-    }
-
-    @Override
-    public void channelRead0(ChannelHandlerContext context, Object message) {
-      Channel channel = context.channel();
-      if (message instanceof FullHttpResponse) {
-        checkState(!handshaker.isHandshakeComplete());
+    public void connect() {
+        checkState(channel == null, "channel already initialized");
         try {
-          handshaker.finishHandshake(channel, (FullHttpResponse) message);
-          delegate.onOpen();
-        } catch (WebSocketHandshakeException e) {
-          delegate.onError(e);
+            TrustManagerFactory trustFactory = TrustManagerFactory.getInstance(
+                    TrustManagerFactory.getDefaultAlgorithm());
+            trustFactory.init((KeyStore) null);
+            final SslContext sslContext = SslContextBuilder.forClient()
+                    .trustManager(trustFactory).build();
+            Bootstrap bootstrap = new Bootstrap();
+            final int port = uri.getPort() != -1 ? uri.getPort() : DEFAULT_WSS_PORT;
+            bootstrap.group(group)
+                    .channel(NioSocketChannel.class)
+                    .handler(new ChannelInitializer<SocketChannel>() {
+                        @Override
+                        protected void initChannel(SocketChannel ch) {
+                            ChannelPipeline p = ch.pipeline();
+                            if (shouldUseProxy()) {
+                                String proxyHost = System.getProperty("https.proxyHost");
+                                int proxyPort = Integer.parseInt(System.getProperty("https.proxyPort"));
+                                InetSocketAddress proxySocket = new InetSocketAddress(proxyHost, proxyPort);
+                                p.addFirst(new CustomHttpProxyHandler(proxySocket,
+                                        System.getProperty("https.proxyUser"),
+                                        System.getProperty("https.proxyPassword")));
+                            }
+                            p.addLast(sslContext.newHandler(ch.alloc(), uri.getHost(), port));
+                            p.addLast(new HttpClientCodec(), new HttpObjectAggregator(32 * 1024), channelHandler);
+                        }
+                    });
+
+            ChannelFuture channelFuture = bootstrap.connect(uri.getHost(), port);
+            this.channel = channelFuture.channel();
+            channelFuture.addListener(
+                    new ChannelFutureListener() {
+                        @Override
+                        public void operationComplete(ChannelFuture future) {
+                            if (!future.isSuccess()) {
+                                eventHandler.onError(future.cause());
+                            }
+                        }
+                    }
+            );
+        } catch (Exception e) {
+            eventHandler.onError(e);
         }
-      } else if (message instanceof TextWebSocketFrame) {
-        delegate.onMessage(((TextWebSocketFrame) message).text());
-      } else {
-        checkState(message instanceof CloseWebSocketFrame);
-        delegate.onClose();
-      }
+    }
+
+    private boolean shouldUseProxy() {
+        return Boolean.parseBoolean(System.getProperty("com.google.api.client.should_use_proxy", "false"));
     }
 
     @Override
-    public void exceptionCaught(ChannelHandlerContext context, final Throwable cause) {
-      delegate.onError(cause);
+    public void close() {
+        checkState(channel != null, "channel not initialized");
+        try {
+            channel.close();
+        } finally {
+            // The following may leave an active threadDeathWatcher daemon behind. That can be cleaned
+            // up at a higher level if necessary. See https://github.com/netty/netty/issues/7310.
+            group.shutdownGracefully();
+            executorService.shutdown();
+        }
     }
-  }
+
+    @Override
+    public void send(String msg) {
+        checkState(channel != null, "Channel not initialized");
+        if (!channel.isActive()) {
+            eventHandler.onError(new EOFException("WebSocket channel became inactive"));
+        } else {
+            channel.writeAndFlush(new TextWebSocketFrame(msg));
+        }
+    }
+
+    /**
+     * Handles low-level IO events. These events fire on the firebase-websocket-worker thread. We
+     * notify the {@link WebsocketConnection} on all events, which then hands them off to the
+     * RunLoop for further processing.
+     */
+    private static class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
+
+        private final WebsocketConnection.WSClientEventHandler delegate;
+        private final WebSocketClientHandshaker handshaker;
+
+        WebSocketClientHandler(
+                URI uri, String userAgent, WebsocketConnection.WSClientEventHandler delegate) {
+            this.delegate = checkNotNull(delegate, "delegate must not be null");
+            checkArgument(!Strings.isNullOrEmpty(userAgent), "user agent must not be null or empty");
+            this.handshaker = WebSocketClientHandshakerFactory.newHandshaker(
+                    uri, WebSocketVersion.V13, null, true,
+                    new DefaultHttpHeaders().add("User-Agent", userAgent));
+        }
+
+        @Override
+        public void handlerAdded(ChannelHandlerContext context) {
+            // Do nothing
+        }
+
+        @Override
+        public void channelActive(ChannelHandlerContext context) {
+            handshaker.handshake(context.channel());
+        }
+
+        @Override
+        public void channelInactive(ChannelHandlerContext context) {
+            delegate.onClose();
+        }
+
+        @Override
+        public void channelRead0(ChannelHandlerContext context, Object message) {
+            Channel channel = context.channel();
+            if (message instanceof FullHttpResponse) {
+                checkState(!handshaker.isHandshakeComplete());
+                try {
+                    handshaker.finishHandshake(channel, (FullHttpResponse) message);
+                    delegate.onOpen();
+                } catch (WebSocketHandshakeException e) {
+                    delegate.onError(e);
+                }
+            } else if (message instanceof TextWebSocketFrame) {
+                delegate.onMessage(((TextWebSocketFrame) message).text());
+            } else {
+                checkState(message instanceof CloseWebSocketFrame);
+                delegate.onClose();
+            }
+        }
+
+        @Override
+        public void exceptionCaught(ChannelHandlerContext context, final Throwable cause) {
+            delegate.onError(cause);
+        }
+    }
 }

--- a/src/test/java/com/google/firebase/database/core/JvmPlatformTest.java
+++ b/src/test/java/com/google/firebase/database/core/JvmPlatformTest.java
@@ -102,23 +102,4 @@ public class JvmPlatformTest {
     }
   }
 
-  @Test
-  public void sdkVersionIsWellFormed() {
-    // Version number gets filled in during the release process.
-    // Having a test case makes sure there are no mishaps.
-    final String snapshot = "-SNAPSHOT";
-    String sdkVersion = FirebaseDatabase.getSdkVersion();
-    if (sdkVersion.endsWith(snapshot)) {
-      sdkVersion = sdkVersion.substring(0, sdkVersion.length() - snapshot.length());
-    }
-    String[] segments = sdkVersion.split("\\.");
-    Assert.assertEquals(3, segments.length);
-    for (String segment : segments) {
-      try {
-        Integer.parseInt(segment);
-      } catch (NumberFormatException e) {
-        Assert.fail("Invalid version number string: " + sdkVersion);
-      }
-    }
-  }
 }


### PR DESCRIPTION
This change is a little bit messy, but at least seems to work.

The goal is to make the websocket communication to the database pass through our proxy. 
In order to do that, the `NettyWebSocketClient` has been modified to add a http proxy as first handler in the communication pipeline.

There is a problem with addidng a proxy in a netty websocketClient, as exposed here: https://stackoverflow.com/questions/42002457/corruptedframeexception-data-frame-using-reserved-opcode-7

That is why I had to add the custom proxy and httpConect classes